### PR TITLE
Fixed broken Atlas Instagram feed using Jucier

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,6 +266,9 @@
         <div class="container">
             <h1 class="text-xs-center header">Social</h1>
             <hr />
+            <script src="https://assets.juicer.io/embed.js" type="text/javascript"></script>
+            <link href="https://assets.juicer.io/embed.css" media="all" rel="stylesheet" type="text/css" />
+            <ul class="juicer-feed" data-feed-id="the_atlas" data-per="6"></ul>
             <div id="atlasFeed" class="row"></div>
         </div>
     </section>

--- a/js/custom.js
+++ b/js/custom.js
@@ -32,6 +32,8 @@ $(document).ready(function(){
 
   var button = "<div class='col col-xs-12 text-white text-xs-center'><a href='https://www.instagram.com/the_atlas/' target='about_blank' class='btn btn-primary'>Open with Instagram</a></div>";
   //Instagram feed stuff.
+  //The commented out code is an outdated feed where the link does not work
+  /*
   $.getJSON("https://aswwu.com/server/feed?name=atlas", function(data){
     var feed =``;
     $.each(data.data, function(i,o){
@@ -52,11 +54,13 @@ $(document).ready(function(){
           `;
       feed += html;
     });
-
-    $("#atlasFeed").append(feed + button);
+    */
+    $("#atlasFeed").append(button);
+    /*
   }).fail(function(){
     $("#atlasFeed").append("<div class='col col-xs-12 text-xs-center'><p><font color='red'>Failed to fetch instagram content.</font></p></div>" + button);
   });
+  */
 
   //Add baristas.
   var baristas = [


### PR DESCRIPTION
I used Jucier to output an instagram feed to the Atlas website. 
This is a temporary fix, as eventually we can use the original endpoint provided by the sever (if we can ever find it).
#4 